### PR TITLE
Fixed quizzler game name box size.

### DIFF
--- a/quiz.css
+++ b/quiz.css
@@ -21,7 +21,6 @@
         .game-cell td {
             cursor: pointer;
             width: 200px;
-            height: 150px;
             margin: 5px;
             padding-left: 10px;
             padding-right: 10px;
@@ -30,6 +29,19 @@
             border-radius: 5px;
             border: 1px solid black;
             color: white;
+        }
+
+        .game-select-question-outer {
+            height: 150px;
+            overflow: hidden;
+            -webkit-transform-style: preserve-3d;
+            -moz-transform-style: preserve-3d;
+            transform-style: preserve-3d;
+        }
+        .game-select-question-inner {
+            position: relative;
+            top: 50%;
+            transform: translateY(-50%);
         }
 
         .game-cell .answered-right{

--- a/quiz.css
+++ b/quiz.css
@@ -13,10 +13,18 @@
             text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
         }
 
+        #pointTable {
+            table-layout: fixed;
+            width: 200px;
+        }
+
         .game-cell td {
             cursor: pointer;
+            width: 200px;
             height: 150px;
             margin: 5px;
+            padding-left: 10px;
+            padding-right: 10px;
             font-size: 30px;
             background-color: #0000CC;
             border-radius: 5px;

--- a/quiz.html
+++ b/quiz.html
@@ -23,16 +23,16 @@
         </thead>
         <tbody class="game-cell">
         <tr>
-            <td class="game-select-question" id="question-0" data-question-number="0"></td>
-            <td class="game-select-question" id="question-2" data-question-number="2"></td>
-            <td class="game-select-question" id="question-4" data-question-number="4"></td>
-            <td class="game-select-question" id="question-6" data-question-number="6"></td>
+            <td class="game-select-question" data-question-number="0"><div class="game-select-question-outer"><div class="game-select-question-inner" id="question-0"></div></div></td>
+            <td class="game-select-question" data-question-number="2"><div class="game-select-question-outer"><div class="game-select-question-inner" id="question-2"></div></div></td>
+            <td class="game-select-question" data-question-number="4"><div class="game-select-question-outer"><div class="game-select-question-inner" id="question-4"></div></div></td>
+            <td class="game-select-question" data-question-number="6"><div class="game-select-question-outer"><div class="game-select-question-inner" id="question-6"></div></div></td>
         </tr>
         <tr>
-            <td class="game-select-question" id="question-1" data-question-number="1"></td>
-            <td class="game-select-question" id="question-3" data-question-number="3"></td>
-            <td class="game-select-question" id="question-5" data-question-number="5"></td>
-            <td class="game-select-question" id="question-7" data-question-number="7"></td>
+            <td class="game-select-question" data-question-number="1"><div class="game-select-question-outer"><div class="game-select-question-inner" id="question-1"></div></div></td>
+            <td class="game-select-question" data-question-number="3"><div class="game-select-question-outer"><div class="game-select-question-inner" id="question-3"></div></div></td>
+            <td class="game-select-question" data-question-number="5"><div class="game-select-question-outer"><div class="game-select-question-inner" id="question-5"></div></div></td>
+            <td class="game-select-question" data-question-number="7"><div class="game-select-question-outer"><div class="game-select-question-inner" id="question-7"></div></div></td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
This fixes the game name box size of Quizzler to 200x150, rather than it widely fluctuating depending on how long and how many words the titles are.

Before:
[![Before](http://i.imgur.com/E6tWcQSm.png)](http://i.imgur.com/E6tWcQS.png)

Now:
[![After Regular](http://i.imgur.com/mjGHJrGm.png)](http://i.imgur.com/mjGHJrG.png)
[![After Too Long](http://i.imgur.com/IG538lKm.png)](http://i.imgur.com/IG538lK.png)

Next step would be to automatically pick smaller font sizes for titles that don't fit.
