### PR TITLE
Avoid recreating segments when shrinking them. Only update the sizes.

### DIFF
--- a/wheel/wheel.html
+++ b/wheel/wheel.html
@@ -71,9 +71,8 @@
 			];
 			
 			segments = initSegments();
-			function initSegments()
+			function updateSizeSegments(segs)
 			{
-				var result = [];
 				var lastAngle = 0;
 				var totalWeight = 0;
 				for (var i = 0; i < wedges.length; ++i)
@@ -85,17 +84,28 @@
 				{
 					var wedge = wedges[i];
 					var wedgeAngle = wedge.weight * unitAngle;
+					segs[i].startAngle = lastAngle;
+					segs[i].endAngle = lastAngle + wedgeAngle;
+					lastAngle += wedgeAngle;
+				}
+			}
+			function initSegments()
+			{
+				var result = [];
+				for (var i = 0; i < wedges.length; ++i)
+				{
+					var wedge = wedges[i];
 					result.push(
 							{
 								text: wedge.text,
-								startAngle: lastAngle,
-								endAngle: lastAngle + wedgeAngle,
+								startAngle: 0,
+								endAngle: 0,
 								color: wedge.color,
 								sound: new Audio(wedge.sound)
 							}
 					);
-					lastAngle += wedgeAngle;
 				}
+				updateSizeSegments(result);
 				return result;
 			}
 			
@@ -261,9 +271,10 @@
 							if (i < 10)
 							{
 								wedges.splice(wheel.hitSegmentIndex, 1);
+								segments.splice(wheel.hitSegmentIndex, 1);
 								wheel.hitSegmentIndex = -1;
 							}
-							segments = initSegments();
+							updateSizeSegments(segments);
 							if (i >= 10)
 							{
 								segments[wheel.hitSegmentIndex].shrinkPct = i / 100;

--- a/wheel/wheel2.html
+++ b/wheel/wheel2.html
@@ -52,9 +52,8 @@
 				{text: "Feelin' Sad", weight: 5, color: '#000000', sound: 'sounds/Sad.ogg'}
 			];
 			segments = initSegments();
-			function initSegments()
+			function updateSizeSegments(segs)
 			{
-				var result = [];
 				var lastAngle = 0;
 				var totalWeight = 0;
 				for (var i = 0; i < wedges.length; ++i)
@@ -66,17 +65,28 @@
 				{
 					var wedge = wedges[i];
 					var wedgeAngle = wedge.weight * unitAngle;
+					segs[i].startAngle = lastAngle;
+					segs[i].endAngle = lastAngle + wedgeAngle;
+					lastAngle += wedgeAngle;
+				}
+			}
+			function initSegments()
+			{
+				var result = [];
+				for (var i = 0; i < wedges.length; ++i)
+				{
+					var wedge = wedges[i];
 					result.push(
 							{
 								text: wedge.text,
-								startAngle: lastAngle,
-								endAngle: lastAngle + wedgeAngle,
+								startAngle: 0,
+								endAngle: 0,
 								color: wedge.color,
 								sound: new Audio(wedge.sound)
 							}
 					);
-					lastAngle += wedgeAngle;
 				}
+				updateSizeSegments(result);
 				return result;
 			}
 			
@@ -242,9 +252,10 @@
 							if (i < 10)
 							{
 								wedges.splice(wheel.hitSegmentIndex, 1);
+								segments.splice(wheel.hitSegmentIndex, 1);
 								wheel.hitSegmentIndex = -1;
 							}
-							segments = initSegments();
+							updateSizeSegments(segments);
 							if (i >= 10)
 							{
 								segments[wheel.hitSegmentIndex].shrinkPct = i / 100;

--- a/wheel/wheelB.html
+++ b/wheel/wheelB.html
@@ -71,9 +71,8 @@
 			];
 			
 			segments = initSegments();
-			function initSegments()
+			function updateSizeSegments(segs)
 			{
-				var result = [];
 				var lastAngle = 0;
 				var totalWeight = 0;
 				for (var i = 0; i < wedges.length; ++i)
@@ -85,17 +84,28 @@
 				{
 					var wedge = wedges[i];
 					var wedgeAngle = wedge.weight * unitAngle;
+					segs[i].startAngle = lastAngle;
+					segs[i].endAngle = lastAngle + wedgeAngle;
+					lastAngle += wedgeAngle;
+				}
+			}
+			function initSegments()
+			{
+				var result = [];
+				for (var i = 0; i < wedges.length; ++i)
+				{
+					var wedge = wedges[i];
 					result.push(
 							{
 								text: wedge.text,
-								startAngle: lastAngle,
-								endAngle: lastAngle + wedgeAngle,
+								startAngle: 0,
+								endAngle: 0,
 								color: wedge.color,
 								sound: new Audio(wedge.sound)
 							}
 					);
-					lastAngle += wedgeAngle;
 				}
+				updateSizeSegments(result);
 				return result;
 			}
 			
@@ -261,9 +271,10 @@
 							if (i < 10)
 							{
 								wedges.splice(wheel.hitSegmentIndex, 1);
+								segments.splice(wheel.hitSegmentIndex, 1);
 								wheel.hitSegmentIndex = -1;
 							}
-							segments = initSegments();
+							updateSizeSegments(segments);
 							if (i >= 10)
 							{
 								segments[wheel.hitSegmentIndex].shrinkPct = i / 100;


### PR DESCRIPTION
This should give a performance improvement (and less RAM usage) when wheel segments are shrinking.

As a sidenote, shouldn't these three wheel code blocks be extracted into one wheel.js or something?
